### PR TITLE
Add `releaseOrderFunds`

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,25 @@ TODO
 
 </details>
 
+<details>
+
+<summary><b>releaseOrderFunds(adNumber)</b>: Given an order number, releases the funds</summary>
+
+- Input:
+
+  - orderNumber: String
+  - authType: "GOOGLE" | "SMS" | "FIDO2" | "FUND_PWD"
+  - confirmPaidType: "quick" | "normal"
+  - code: String
+
+- Result
+
+```
+TODO
+```
+
+</details>
+
 ### TODO
 
 - [ ] Codegen js api docs (typedoc)

--- a/src/binance-p2p/index.ts
+++ b/src/binance-p2p/index.ts
@@ -132,5 +132,22 @@ export class BinanceP2P {
     return this._updateAd({ adNumber, status: 3 });
   }
 
+  async releaseOrderFunds(params: ReleaseOrderFundsParams) {
+    const { url, data } = this._createRequestPayload(URLS.RELEASE_ORDER_FUNDS, {
+      authType: params.authType,
+      code: params.code,
+      confirmPaidType: params.confirmPaidType,
+      emailVerifyCode: params.emailVerifyCode,
+      googleVerifyCode: params.googleVerifyCode,
+      mobileVerifyCode: params.mobileVerifyCode,
+      orderNumber: params.orderNumber,
+      payId: params.payId,
+      yubikeyVerifyCode: params.yubikeyVerifyCode,
+      timestamp: Date.now(),
+    });
+
+    return this.http.post(url, data).then((response) => response.data);
+  }
+
   // TODO: delete ad (so funds are available again)
 }

--- a/src/binance-p2p/urls.ts
+++ b/src/binance-p2p/urls.ts
@@ -5,4 +5,5 @@ export const URLS = {
   ORDER_DETAIL: "/sapi/v1/c2c/orderMatch/getUserOrderDetail",
   ORDER_CHAT_MESSAGES: "/sapi/v1/c2c/chat/retrieveChatMessagesWithPagination",
   UPDATE_ORDER: "/sapi/v1/c2c/ads/updateStatus",
+  RELEASE_ORDER_FUNDS: "/sapi/v1/c2c/orderMatch/releaseCoin",
 };

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -42,4 +42,16 @@ declare global {
   interface FetchTradeHistoryParams {
     tradeType: BinanceTradeTypes;
   }
+
+  interface ReleaseOrderFundsParams {
+    authType?: "GOOGLE" | "SMS" | "FIDO2" | "FUND_PWD";
+    code?: string;
+    confirmPaidType?: "quick" | "normal";
+    emailVerifyCode?: string;
+    googleVerifyCode?: string;
+    mobileVerifyCode?: string;
+    orderNumber: string;
+    payId?: number; // ad payment method id
+    yubikeyVerifyCode?: string;
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/tony-tripulca/binance-p2p/issues/3

Added `BinanceP2P` instance method `releaseOrderFunds` which allows to release the funds of a P2P order (& the platform automatically finishes it, without no further action needed)

I got this working on a closed-source application & it require a couple of other things:

1. A way to generate 2fa code (I use [otplib](https://www.npmjs.com/package/otplib))
2. A queue, since Binance doesn't alllow to use the same 2fa code, i.e: need to wait used codes to expire & use a new one. a simple FIFO queue works nicely.
3. Detect when the payment has been received, as a pre-check in order to release funds after.
  - This requires event handling from the order events & many other things. Would require to create some sort of bot on top of this library. & support some sort of plugin system, e.g: automate checking if a payment has been received, etc. A database is likely needed as well. It's not my current priority to open source this though.
  
  In order to release funds of an order with this method, just need to do something like this:
  
  ```js
    // NOTE: also need to handle concurrency, i.e: can't use the same 2fa code twice
    const twoFactor = get2FACode(); // you need to handle this yourself
     const resp = await p2p.releaseOrderFunds({
        orderNumber, // you can get this by processing websockets events
        authType: "GOOGLE",
        confirmPaidType: "normal",
        code: String(twoFactor.code),
      });
   ```