### PR TITLE
Add `markOrderAsPayed`

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,27 @@ TODO
 
 <details>
 
+<summary><b>markOrderAsPayed(params)</b>: Marks an order as payed</summary>
+
+- Params:
+
+```
+{
+  orerNumber: String,
+  payId: String
+}
+```
+
+- Result
+
+```
+TODO
+```
+
+</details>
+
+<details>
+
 <summary><b>startAd(adNumber)</b>: Marks ad as published</summary>
 
 - Input:

--- a/src/binance-p2p/urls.ts
+++ b/src/binance-p2p/urls.ts
@@ -4,5 +4,6 @@ export const URLS = {
   ADS_SEARCH: "/sapi/v1/c2c/ads/search",
   ORDER_DETAIL: "/sapi/v1/c2c/orderMatch/getUserOrderDetail",
   ORDER_CHAT_MESSAGES: "/sapi/v1/c2c/chat/retrieveChatMessagesWithPagination",
+  MARK_ORDER_AS_PAID: "/sapi/v1/c2c/orderMatch/markOrderAsPaid",
   UPDATE_ORDER: "/sapi/v1/c2c/ads/updateStatus",
 };

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -39,6 +39,11 @@ declare global {
     status: number;
   }
 
+  interface MarkOrderAsPayedParams {
+    orderNumber: string;
+    payId: number;
+  }
+
   interface FetchTradeHistoryParams {
     tradeType: BinanceTradeTypes;
   }


### PR DESCRIPTION
Fixes https://github.com/tony-tripulca/binance-p2p/issues/2

Added BinanceP2P instance method `markOrderAsPayed which allows to mark an order as payed.

Example of usage

```js
 const order = await p2p.fetchOrderDetail(orderNumber);
 const resp = await p2p.markOrderAsPayed({
      orderNumber,
      payId: order.selectedPayId,
 });
```